### PR TITLE
config/environments/production.rでの不要なコードの削除

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,6 +76,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  config.threadsafe!
-  config.dependency_loading = true if $rails_rake_task
 end


### PR DESCRIPTION
# WHAT   config.threadsafe! と config.dependency_loading = true if $rails_rake_task の２つの行を削除した。
# WHY carrierwaveの実装の時にデバックで使用したが、エラーの原因と関係しておらず、デバック後、上記のコードを消しても問題なく動いたため。
