### PR TITLE
top/index.html.hamlのページネーションのところのエラーのデバック。

### DIFF
--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -36,8 +36,7 @@
 .text-center
   %ul.pagination
     %li.disabled
-      %a{aria: { label: "Previous"} href: "#"}
-        %span{aria: { hidden: "true"}} «
+      = link_to "«", "#", aria: {label: "Previous"}, aria: {hidden: "true"}
     %li.active
       %a{href: "#"}
         1
@@ -51,5 +50,4 @@
     %li
       %a{href: "#"} 5
     %li
-      %a{aria: { label: "Next" } href: "#"}
-        %span{aria: { hidden: "true"}} »
+      = link_to "»", "#", aria: {label: "Next"}, aria: {hidden: "true"}


### PR DESCRIPTION
# WHAT

top/index.html.hamlのページネーションのところのエラーのデバック。見栄えをよくするために、link_toに書き換えた。
# WHY　ハッシュ記法で、カンマがなくてエラーしていたため。
