### PR TITLE
ユーザー情報編集画面のデザイン適用とユーザー情報抹消機能のコメントアウト

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -15,7 +15,7 @@
 
           .user-image.col-md-2
             #user_avatar.media-object
-              %img{ style: "display:none; width:100%; height:100%;", alt: "64*64", data: { holder: { rendered: "true"}}, data: { src: "holder.js/64*64"}}
+              %img{ style: "display:none; width:100%; height:100%;", alt: "64*64", data: { holder: { rendered: "true" }}, data: { src: "holder.js/64*64" }}
               %button{ class: "btn btn-primary" }
                 Add Image
               #upload_avatar
@@ -57,11 +57,11 @@
           .row.text-center.user-btn
             = f.submit "SAVE", class: "btn btn-lg btn-primary btn-block"
 
-        -# %h3
-        -#   Cancel My Account
+        %h3
+          Cancel My Account
 
-        -# %p
-        -#   Unhappy?
-        -#   = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete
+        %p
+          Unhappy?
+          = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete
 
-        -# = link_to "Back", :back
+        = link_to "Back", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,92 +1,67 @@
-%h2
-  Edit Profile
+.container.user-new#user-new
+  .col-md-8.col-md-offset-2
+    %header.row.user-nav.row
+      .col-md-12
+        %h2
+          Edit Profile
 
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = devise_error_messages!
+        = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+          = devise_error_messages!
 
-  %div(class="field")
-    = f.label :username
-    = f.text_field :username, autofocus: true
+          .user-name_image.row
+            .user-name.col-md-10
+              #user_username
+                = f.text_field :username, autofocus: true, placeholder: "Username"
 
+          .user-image.col-md-2
+            #user_avatar.media-object
+              %img{ style: "display:none; width:100%; height:100%;", alt: "64*64", data: { holder: { rendered: "true"}}, data: { src: "holder.js/64*64"}}
+              %button{ class: "btn btn-primary" }
+                Add Image
+              #upload_avatar
+                = f.file_field :avatar
 
-  %div(class="field")
-    = f.label :avatar
-    = f.file_field :avatar
-
-  %div(class="field")
-    = f.label :email
-    = f.email_field :email
-
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for:
-      = resource.unconfirmed_email
-
-  %div(class="field")
-    = f.label :password
-    %i
-      (leave blak if you don't want to change it)
-    = f.password_field :password, autocomplete: "off"
+          #user_email
+            = f.email_field :email, class: "user-email", placeholder: "Email", autofocus: "autofocus"
 
 
-  %div(class="field")
-    = f.label :password_confirmation
-    = f.password_field :password_confirmation, autocomplete: "off"
+          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+            %div
+              Currently waiting confirmation for:
+              = resource.unconfirmed_email
 
-  %div(class="field")
-    = f.label :current_password
-    %i
-      (we need your current password to confirm your changes)
-    = f.password_field :current_password, autocomplete: "off"
+          #user_password
+            = f.password_field :password, autocomplete: "off", placeholder: "Password", class: "user-password"
 
-  %div(class="actions")
-    = f.submit "SAVE"
+          %h4
+            Member of
+          .user-user-member.row
+            .user-name.col-md-12
+              #user_group
+                = f.text_field :team, placeholder: "Member", autofocus: "autofocus"
 
-%h3
-  Cancel My Account
+          %h4
+            Profile
+          .user-user-profile.row
+            .user-name.col-md-12
+              #user_profile
+                = f.text_area :profile, placeholder: "Profile", cols: "30", rows: "4"
 
-%p
-  Unhappy?
-  = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete
+          %h4
+            Works
+          .user-name_image.row
+            .user-name.col-md-12
+              #user_work
+                = f.text_area :works, placeholder: "Works", cols: "30", rows: "4"
 
-= link_to "Back", :back
+          .row.text-center.user-btn
+            = f.submit "SAVE", class: "btn btn-lg btn-primary btn-block"
 
-/ <h2>Edit <%= resource_name.to_s.humanize %></h2>
+        -# %h3
+        -#   Cancel My Account
 
-/ <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-/   <%= devise_error_messages! %>
+        -# %p
+        -#   Unhappy?
+        -#   = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete
 
-/   <div class="field">
-/     <%= f.label :email %><br />
-/     <%= f.email_field :email, autofocus: true %>
-/   </div>
-
-/   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-/     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-/   <% end %>
-
-/   <div class="field">
-/     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-/     <%= f.password_field :password, autocomplete: "off" %>
-/   </div>
-
-/   <div class="field">
-/     <%= f.label :password_confirmation %><br />
-/     <%= f.password_field :password_confirmation, autocomplete: "off" %>
-/   </div>
-
-/   <div class="field">
-/     <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-/     <%= f.password_field :current_password, autocomplete: "off" %>
-/   </div>
-
-/   <div class="actions">
-/     <%= f.submit "Update" %>
-/   </div>
-/ <% end %>
-
-/ <h3>Cancel my account</h3>
-
-/ <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-/ <%= link_to "Back", :back %>
+        -# = link_to "Back", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -15,7 +15,7 @@
 
           .user-image.col-md-2
             #user_avatar.media-object
-              %img{ style: "display:none; width:100%; height:100%;", alt: "64*64", data: { holder: { rendered: "true" }}, data: { src: "holder.js/64*64" }}
+              %img{ style: "display:none; width:100%; height:100%;", alt: "64*64", data: { holder: { rendered: "true" } }, data: { src: "holder.js/64*64" } }
               %button{ class: "btn btn-primary" }
                 Add Image
               #upload_avatar
@@ -23,7 +23,6 @@
 
           #user_email
             = f.email_field :email, class: "user-email", placeholder: "Email", autofocus: "autofocus"
-
 
           - if devise_mapping.confirmable? && resource.pending_reconfirmation?
             %div
@@ -57,11 +56,15 @@
           .row.text-center.user-btn
             = f.submit "SAVE", class: "btn btn-lg btn-primary btn-block"
 
-        %h3
-          Cancel My Account
+        %h2
+          Delete My Account
 
         %p
           Unhappy?
-          = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete
+          .row.text-center.user-btn
+            = button_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, class: "btn btn-lg btn-primary btn-block", method: :delete
 
-        = link_to "Back", :back
+
+
+
+


### PR DESCRIPTION
# WHAT

ユーザー情報編集画面のデザイン適用とユーザー情報抹消機能のコメントアウト
# WHY

編集画面の見栄えをよくするため。抹消機能は元のプロトスペースを見たら特に設定されていなかったため削除。
